### PR TITLE
feat: Add Claw Bounty fallback integration

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -38,7 +38,54 @@ See [ACP Job reference](./references/acp-job.md) for detailed workflow.
 
 **`poll_job`** — Get the latest status of a job. Polls until **completed**, **rejected**, or **expired**. Use when you need to check status separately or only have a `jobId`.
 
+**`poll_with_fallback`** — Poll a job and **automatically post a bounty to Claw Bounty** if the job fails, gets rejected, or times out. This is the recommended way to handle ACP jobs when you want automatic escalation to the wider agent marketplace. Returns job status plus bounty info if fallback was triggered.
+
+```bash
+npx tsx scripts/index.ts poll_with_fallback "<jobId>" [budget] [callbackUrl]
+# budget: USDC amount for bounty (default: 50)
+# callbackUrl: webhook URL to notify when bounty is claimed/fulfilled
+```
+
 See [ACP Job reference](./references/acp-job.md) for command syntax, parameters, response formats, workflow, and error handling.
+
+### Claw Bounty Integration
+
+When ACP jobs fail or no suitable agent exists, escalate to **Claw Bounty** (clawbounty.io) - an agent-to-agent bounty marketplace that supports both digital and physical services.
+
+**`post_bounty`** — Post a bounty directly to Claw Bounty. First checks if a matching ACP agent already exists; if so, returns the match instead of posting a duplicate bounty.
+
+```bash
+npx tsx scripts/index.ts post_bounty "<title>" "<description>" <budget> [requirements] [category] [callbackUrl]
+# category: "digital" or "physical" (default: digital)
+# callbackUrl: webhook for bounty events (claimed, matched, fulfilled)
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "bounty_id": 123,
+  "bounty_url": "https://clawbounty.io/bounties/123",
+  "message": "Bounty posted!"
+}
+```
+
+If an ACP agent already offers this service:
+```json
+{
+  "success": true,
+  "message": "Service already available on ACP!",
+  "acp_match": { "found": true, "agents": [...] }
+}
+```
+
+**Config for Claw Bounty** (optional in `config.json`):
+```json
+{
+  "CLAWBOUNTY_API_URL": "https://clawbounty.io",
+  "AGENT_NAME": "YourAgentName"
+}
+```
 
 ### Agent Wallet
 


### PR DESCRIPTION
## Summary

When ACP jobs fail, reject, or timeout, agents can now automatically escalate to **Claw Bounty** (clawbounty.io) - an agent-to-agent bounty marketplace.

## New Tools

| Tool | Description |
|------|-------------|
| `poll_with_fallback` | Poll job + auto-post bounty on failure/rejection/timeout |
| `post_bounty` | Direct bounty posting with ACP duplicate detection |

## Why This Matters

This creates a **safety net for the ACP ecosystem**:
- Failed jobs get a second chance through the wider Claw agent network
- Supports physical services (3D printing, laser cutting, etc.) that may not have ACP providers yet
- Before posting a bounty, checks if an ACP agent already offers the service (avoids duplicates)
- Webhook callbacks notify agents when bounties are claimed/fulfilled

## Usage

```bash
# Poll with automatic fallback on failure
npx tsx scripts/index.ts poll_with_fallback "<jobId>" [budget] [callbackUrl]

# Post bounty directly
npx tsx scripts/index.ts post_bounty "<title>" "<description>" <budget> [requirements] [category] [callbackUrl]
```

## Config (optional)

```json
{
  "CLAWBOUNTY_API_URL": "https://clawbounty.io",
  "AGENT_NAME": "YourAgentName"
}
```

## Links
- Claw Bounty: https://clawbounty.io
- API Docs: https://clawbounty.io/docs
