### PR TITLE
feat: Add ClawdTalk voice integration for Virtuals agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ CLI tool for the [Agent Commerce Protocol (ACP)](https://app.virtuals.io/acp) by
 - **ACP Marketplace** — browse, buy, and sell services with other agents
 - **Agent Token** — launch a token for capital formation and revenue accrual
 - **Seller Runtime** — register offerings and serve them via WebSocket
+- **Phone Number** — voice calls and SMS for your agent via ClawdTalk
 
 ## Quick Start
 
@@ -69,6 +70,15 @@ serve stop                             Stop the seller runtime
 serve status                           Show seller runtime status
 serve logs                             Show recent seller logs
 serve logs --follow                    Tail seller logs in real time
+
+phone setup                            Configure phone number for voice/SMS
+phone status                           Show phone number and connection status
+phone call <number> [msg]              Make an outbound voice call
+phone call-status <id>                 Check call status
+phone call-end <id>                    End an active call
+phone sms <number> <msg> [--media url] Send an SMS message (optional media)
+phone sms-list [contact]               List recent SMS messages
+phone connect                          Start WebSocket for inbound calls
 ```
 
 ### Examples
@@ -143,6 +153,50 @@ The workflow:
 To delete a resource: `acp sell resource delete <name>`
 
 See [Seller reference](./references/seller.md) for the full guide on resources.
+
+## ClawdTalk Voice Integration
+
+Give your Virtuals agent a phone number for voice calls and SMS. Powered by [ClawdTalk](https://clawdtalk.com).
+
+### Setup
+
+1. Get an API key at [clawdtalk.com](https://clawdtalk.com)
+2. Run `acp phone setup` and enter your API key
+3. Your agent now has a phone number!
+
+### Usage
+
+```bash
+# Check your phone number and status
+acp phone status
+
+# Make an outbound call
+acp phone call +15551234567 "Hello from my agent"
+
+# Send an SMS
+acp phone sms +15551234567 "Quick update from your agent"
+
+# Send SMS with media
+acp phone sms +15551234567 "Check this out" --media https://example.com/image.jpg
+
+# List recent messages
+acp phone sms-list
+
+# Start listening for inbound calls (WebSocket)
+acp phone connect
+```
+
+### How It Works
+
+- **Voice calls**: Inbound calls are transcribed via Telnyx, processed by your agent, and responses are spoken back via TTS
+- **SMS**: Send and receive text messages through the ClawdTalk API
+- **WebSocket**: The `phone connect` command starts a persistent WebSocket connection for real-time inbound call handling
+- **No server required**: The WebSocket client connects outbound to ClawdTalk's servers
+
+### Requirements
+
+- ClawdTalk account and API key ([clawdtalk.com](https://clawdtalk.com))
+- Active Virtuals agent (run `acp setup` first)
 
 ## Configuration
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -118,6 +118,28 @@ See [Seller reference](./references/seller.md) for the full guide on creating an
 
 > Once the seller runtime is started, it handles everything automatically — accepting requests, requesting payment, delivering results/output by executing your handlers implemented. You do not need to manually trigger any steps or poll for jobs.
 
+### ClawdTalk Voice Integration
+
+Give your Virtuals agent a phone number for voice calls and SMS. Requires a [ClawdTalk](https://clawdtalk.com) account and API key.
+
+**`acp phone setup`** — Configure ClawdTalk integration. Prompts for API key and verifies connection. Run this first.
+
+**`acp phone status`** — Show the phone number assigned to your agent and connection status. Returns JSON with `phone_number`, `status`, and `websocket` status.
+
+**`acp phone call <number> [message]`** — Make an outbound voice call. The message is spoken as the greeting. Returns JSON with `call_id`, `to`, and `status`.
+
+**`acp phone call-status <call-id>`** — Check the status of an outbound call. Returns JSON with `call_id`, `status`, `duration`, and `to`.
+
+**`acp phone call-end <call-id>`** — End an active call.
+
+**`acp phone sms <number> <message> [--media url]`** — Send an SMS message. Optionally attach media via URL. Returns JSON with `message_id`, `to`, and `status`.
+
+**`acp phone sms-list [contact]`** — List recent SMS messages. Optionally filter by contact number. Returns JSON array of messages.
+
+**`acp phone connect`** — Start a WebSocket connection for inbound calls. Runs continuously until interrupted (Ctrl+C). Handles incoming calls and SMS in real-time.
+
+**Note:** The ClawdTalk API key is stored in `config.json` under `clawdtalk.api_key`. Get your key at [clawdtalk.com](https://clawdtalk.com).
+
 ## File structure
 
 - **Repo root** — `SKILL.md`, `package.json`, `config.json` (do not commit). Run all commands from here.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "axios": "^1.13.4",
     "dotenv": "^16.4.5",
-    "socket.io-client": "^4.8.1"
+    "socket.io-client": "^4.8.1",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "tsx": "^4.19.2",

--- a/src/commands/phone.ts
+++ b/src/commands/phone.ts
@@ -1,0 +1,447 @@
+// =============================================================================
+// acp phone setup   — Configure ClawdTalk voice integration
+// acp phone status  — Check phone number status
+// acp phone call    — Make an outbound voice call
+// acp phone sms     — Send an SMS message
+// =============================================================================
+
+import * as output from "../lib/output.js";
+import { readConfig, writeConfig, ROOT } from "../lib/config.js";
+import readline from "readline";
+import WebSocket from "ws";
+import axios from "axios";
+
+// -- Types --
+
+interface ClawdTalkConfig {
+  api_key?: string;
+  server?: string;
+  phone_number?: string;
+}
+
+interface PhoneConfig {
+  clawdtalk?: ClawdTalkConfig;
+}
+
+// -- Helpers --
+
+const CLAWDTALK_SERVER = "https://clawdtalk.com";
+
+function getPhoneConfig(): PhoneConfig {
+  const config = readConfig();
+  return config as PhoneConfig;
+}
+
+function savePhoneConfig(phoneConfig: PhoneConfig): void {
+  const config = readConfig();
+  config.clawdtalk = phoneConfig.clawdtalk;
+  writeConfig(config);
+}
+
+function question(rl: readline.Interface, prompt: string): Promise<string> {
+  return new Promise((resolve) => rl.question(prompt, resolve));
+}
+
+// -- Commands --
+
+/**
+ * Setup ClawdTalk integration - prompts for API key and verifies connection
+ */
+export async function setup(): Promise<void> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  try {
+    output.heading("ClawdTalk Voice Integration");
+    output.log("");
+    output.log("  Give your Virtuals agent a phone number for voice calls and SMS.");
+    output.log("  Get your API key at: https://clawdtalk.com");
+    output.log("");
+
+    const config = getPhoneConfig();
+    const existingKey = config.clawdtalk?.api_key;
+
+    if (existingKey) {
+      output.log(`  Existing API key: ${existingKey.slice(0, 8)}...${existingKey.slice(-4)}`);
+      const overwrite = await question(rl, "  Update API key? [y/N]: ");
+      if (overwrite.toLowerCase() !== "y") {
+        output.log("\n  Keeping existing configuration.\n");
+        return;
+      }
+    }
+
+    const apiKey = await question(rl, "  Enter your ClawdTalk API key: ");
+    
+    if (!apiKey || !apiKey.startsWith("cc_")) {
+      output.fatal("Invalid API key. Must start with 'cc_'");
+      return;
+    }
+
+    // Verify API key by checking status
+    output.log("\n  Verifying API key...");
+    
+    try {
+      const response = await axios.get(`${CLAWDTALK_SERVER}/api/status`, {
+        headers: { "Authorization": `Bearer ${apiKey}` },
+        timeout: 10000,
+      });
+
+      const data = response.data;
+      
+      savePhoneConfig({
+        clawdtalk: {
+          api_key: apiKey,
+          server: CLAWDTALK_SERVER,
+          phone_number: data.phone_number,
+        },
+      });
+
+      output.log("");
+      output.success("ClawdTalk configured successfully!");
+      output.field("Phone Number", data.phone_number || "Not assigned");
+      output.log("");
+      output.log("  Your Virtuals agent can now:");
+      output.log("    • Receive voice calls");
+      output.log("    • Make outbound calls (acp phone call)");
+      output.log("    • Send and receive SMS (acp phone sms)");
+      output.log("");
+
+    } catch (e: any) {
+      if (e.response?.status === 401) {
+        output.fatal("Invalid API key. Please check and try again.");
+      } else {
+        output.fatal(`Failed to verify API key: ${e.message}`);
+      }
+    }
+
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Show current phone number and connection status
+ */
+export async function status(): Promise<void> {
+  const config = getPhoneConfig();
+
+  output.heading("ClawdTalk Status");
+
+  if (!config.clawdtalk?.api_key) {
+    output.log("");
+    output.warn("  Not configured. Run: acp phone setup");
+    output.log("");
+    return;
+  }
+
+  try {
+    const response = await axios.get(`${config.clawdtalk.server || CLAWDTALK_SERVER}/api/status`, {
+      headers: { "Authorization": `Bearer ${config.clawdtalk.api_key}` },
+      timeout: 10000,
+    });
+
+    const data = response.data;
+
+    output.output(
+      {
+        phone_number: data.phone_number,
+        status: data.status || "active",
+        websocket: data.websocket_connected ? "connected" : "disconnected",
+      },
+      (info) => {
+        output.field("Phone Number", info.phone_number || "Not assigned");
+        output.field("Status", info.status);
+        output.field("WebSocket", info.websocket);
+        output.log("");
+      }
+    );
+
+  } catch (e: any) {
+    output.fatal(`Failed to check status: ${e.message}`);
+  }
+}
+
+/**
+ * Make an outbound voice call
+ */
+export async function call(to: string, message?: string): Promise<void> {
+  const config = getPhoneConfig();
+
+  if (!config.clawdtalk?.api_key) {
+    output.fatal("Not configured. Run: acp phone setup");
+    return;
+  }
+
+  if (!to) {
+    output.fatal("Phone number required. Usage: acp phone call +15551234567 [\"greeting message\"]");
+    return;
+  }
+
+  try {
+    output.log(`\n  Calling ${to}...`);
+
+    const response = await axios.post(
+      `${config.clawdtalk.server || CLAWDTALK_SERVER}/api/call`,
+      {
+        to,
+        greeting: message || "Hello, this is your Virtuals agent calling.",
+      },
+      {
+        headers: { "Authorization": `Bearer ${config.clawdtalk.api_key}` },
+        timeout: 30000,
+      }
+    );
+
+    const data = response.data;
+
+    output.output(
+      {
+        call_id: data.call_id,
+        to: to,
+        status: data.status || "initiated",
+      },
+      (info) => {
+        output.success("Call initiated!");
+        output.field("Call ID", info.call_id);
+        output.field("To", info.to);
+        output.field("Status", info.status);
+        output.log("");
+        output.log("  Check status: acp phone call-status " + info.call_id);
+        output.log("  End call: acp phone call-end " + info.call_id);
+        output.log("");
+      }
+    );
+
+  } catch (e: any) {
+    output.fatal(`Failed to make call: ${e.response?.data?.error || e.message}`);
+  }
+}
+
+/**
+ * Check outbound call status
+ */
+export async function callStatus(callId: string): Promise<void> {
+  const config = getPhoneConfig();
+
+  if (!config.clawdtalk?.api_key) {
+    output.fatal("Not configured. Run: acp phone setup");
+    return;
+  }
+
+  if (!callId) {
+    output.fatal("Call ID required. Usage: acp phone call-status <call-id>");
+    return;
+  }
+
+  try {
+    const response = await axios.get(
+      `${config.clawdtalk.server || CLAWDTALK_SERVER}/api/call/${callId}`,
+      {
+        headers: { "Authorization": `Bearer ${config.clawdtalk.api_key}` },
+        timeout: 10000,
+      }
+    );
+
+    const data = response.data;
+
+    output.output(
+      {
+        call_id: data.call_id,
+        status: data.status,
+        duration: data.duration,
+        to: data.to,
+      },
+      (info) => {
+        output.heading("Call Status");
+        output.field("Call ID", info.call_id);
+        output.field("Status", info.status);
+        output.field("To", info.to);
+        if (info.duration) output.field("Duration", `${info.duration}s`);
+        output.log("");
+      }
+    );
+
+  } catch (e: any) {
+    output.fatal(`Failed to get call status: ${e.response?.data?.error || e.message}`);
+  }
+}
+
+/**
+ * End an active call
+ */
+export async function callEnd(callId: string): Promise<void> {
+  const config = getPhoneConfig();
+
+  if (!config.clawdtalk?.api_key) {
+    output.fatal("Not configured. Run: acp phone setup");
+    return;
+  }
+
+  if (!callId) {
+    output.fatal("Call ID required. Usage: acp phone call-end <call-id>");
+    return;
+  }
+
+  try {
+    const response = await axios.post(
+      `${config.clawdtalk.server || CLAWDTALK_SERVER}/api/call/${callId}/end`,
+      {},
+      {
+        headers: { "Authorization": `Bearer ${config.clawdtalk.api_key}` },
+        timeout: 10000,
+      }
+    );
+
+    output.success("Call ended.");
+
+  } catch (e: any) {
+    output.fatal(`Failed to end call: ${e.response?.data?.error || e.message}`);
+  }
+}
+
+/**
+ * Send an SMS message
+ */
+export async function sms(to: string, body: string, media?: string): Promise<void> {
+  const config = getPhoneConfig();
+
+  if (!config.clawdtalk?.api_key) {
+    output.fatal("Not configured. Run: acp phone setup");
+    return;
+  }
+
+  if (!to || !body) {
+    output.fatal('Phone number and message required. Usage: acp phone sms +15551234567 "Hello!" [--media url]');
+    return;
+  }
+
+  try {
+    const payload: Record<string, any> = { to, body };
+    if (media) payload.media = media;
+
+    const response = await axios.post(
+      `${config.clawdtalk.server || CLAWDTALK_SERVER}/api/sms`,
+      payload,
+      {
+        headers: { "Authorization": `Bearer ${config.clawdtalk.api_key}` },
+        timeout: 10000,
+      }
+    );
+
+    const data = response.data;
+
+    output.output(
+      {
+        message_id: data.message_id,
+        to: to,
+        status: data.status || "sent",
+      },
+      (info) => {
+        output.success("SMS sent!");
+        output.field("Message ID", info.message_id);
+        output.field("To", info.to);
+        output.field("Status", info.status);
+        output.log("");
+      }
+    );
+
+  } catch (e: any) {
+    output.fatal(`Failed to send SMS: ${e.response?.data?.error || e.message}`);
+  }
+}
+
+/**
+ * List recent SMS messages
+ */
+export async function smsList(contact?: string): Promise<void> {
+  const config = getPhoneConfig();
+
+  if (!config.clawdtalk?.api_key) {
+    output.fatal("Not configured. Run: acp phone setup");
+    return;
+  }
+
+  try {
+    const params = contact ? { contact } : {};
+    const response = await axios.get(
+      `${config.clawdtalk.server || CLAWDTALK_SERVER}/api/sms`,
+      {
+        params,
+        headers: { "Authorization": `Bearer ${config.clawdtalk.api_key}` },
+        timeout: 10000,
+      }
+    );
+
+    const messages = response.data.messages || [];
+
+    output.output(
+      { messages },
+      (data) => {
+        output.heading("SMS Messages");
+        if (data.messages.length === 0) {
+          output.log("  No messages found.\n");
+          return;
+        }
+        for (const msg of data.messages) {
+          const dir = msg.direction === "inbound" ? "←" : "→";
+          output.log(`  ${dir} ${msg.from || msg.to}: ${msg.body.slice(0, 50)}...`);
+        }
+        output.log("");
+      }
+    );
+
+  } catch (e: any) {
+    output.fatal(`Failed to list SMS: ${e.response?.data?.error || e.message}`);
+  }
+}
+
+/**
+ * Start the WebSocket connection for inbound calls
+ */
+export async function connect(): Promise<void> {
+  const config = getPhoneConfig();
+
+  if (!config.clawdtalk?.api_key) {
+    output.fatal("Not configured. Run: acp phone setup");
+    return;
+  }
+
+  const server = config.clawdtalk.server || CLAWDTALK_SERVER;
+  const wsUrl = server.replace("https://", "wss://").replace("http://", "ws://") + "/ws";
+
+  output.log(`\n  Connecting to ${wsUrl}...`);
+
+  const ws = new WebSocket(wsUrl, {
+    headers: {
+      "Authorization": `Bearer ${config.clawdtalk.api_key}`,
+    },
+  });
+
+  ws.on("open", () => {
+    output.success("WebSocket connected. Listening for calls...");
+    output.log("  Press Ctrl+C to disconnect.\n");
+  });
+
+  ws.on("message", (data) => {
+    try {
+      const event = JSON.parse(data.toString());
+      output.log(`  Event: ${event.type} - ${JSON.stringify(event.data)}`);
+    } catch {
+      output.log(`  Message: ${data.toString()}`);
+    }
+  });
+
+  ws.on("error", (err) => {
+    output.fatal(`WebSocket error: ${err.message}`);
+  });
+
+  ws.on("close", () => {
+    output.log("\n  WebSocket disconnected.\n");
+    process.exit(0);
+  });
+
+  // Keep process alive
+  process.stdin.resume();
+}


### PR DESCRIPTION
## Summary

This PR adds ClawdTalk voice integration, giving every Virtuals agent the ability to have a real phone number for voice calls and SMS.

## What's New

### `acp phone` Command Group

```bash
acp phone setup                            # Configure phone number
acp phone status                           # Show phone number and status
acp phone call +15551234567 "Hello!"       # Make outbound call
acp phone call-status <id>                 # Check call status
acp phone call-end <id>                    # End active call
acp phone sms +15551234567 "Message"       # Send SMS
acp phone sms-list [contact]               # List messages
acp phone connect                          # Start WebSocket for inbound calls
```

## Features

- **Voice Calls**: Inbound calls transcribed via Telnyx, processed by the agent, responses spoken via TTS
- **SMS**: Send and receive text messages with optional media attachments
- **WebSocket Connection**: `phone connect` maintains real-time connection for inbound calls
- **No Server Required**: WebSocket client connects outbound to ClawdTalk servers

## Integration

- Stores ClawdTalk API key in existing `config.json` under `clawdtalk.api_key`
- Follows existing command patterns from `wallet.ts`, `token.ts`
- Uses same output formatting (`src/lib/output.js`)
- Updates `SKILL.md` with agent-friendly documentation

## Requirements

- [ClawdTalk](https://clawdtalk.com) account and API key
- Active Virtuals agent (configured via `acp setup`)

## Files Changed

- `src/commands/phone.ts` — New command handler (400+ lines)
- `bin/acp.ts` — CLI routing and help text
- `README.md` — User documentation
- `SKILL.md` — Agent skill instructions
- `package.json` — Added `ws` dependency

## Testing

```bash
cd openclaw-acp
npm install
acp phone setup  # Enter ClawdTalk API key
acp phone status
```

---

*Every Virtuals agent deserves a phone number.* 📞