### PR TITLE
fix(security): harden seller, auth, and CLI

### DIFF
--- a/src/deploy/railway.ts
+++ b/src/deploy/railway.ts
@@ -5,7 +5,7 @@
 // project path. We read/write that to manage per-agent project linking.
 // =============================================================================
 
-import { execSync, spawn } from "child_process";
+import { execSync, execFileSync, spawn } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -154,14 +154,14 @@ export function hasLinkedService(): boolean {
 // -- Variables --
 
 export function setVariable(key: string, value: string): void {
-  execSync(`railway variables set ${key}="${value}"`, {
+  execFileSync("railway", ["variables", "set", `${key}=${value}`], {
     ...EXEC_OPTS,
     stdio: ["pipe", "pipe", "pipe"],
   });
 }
 
 export function deleteVariable(key: string): void {
-  execSync(`railway variables delete ${key}`, {
+  execFileSync("railway", ["variables", "delete", key], {
     ...EXEC_OPTS,
     stdio: ["pipe", "pipe", "pipe"],
   });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -103,7 +103,8 @@ export async function getAuthUrl(): Promise<AuthUrlResponse> {
 
 export async function getAuthStatus(requestId: string): Promise<AuthStatusResponse | null> {
   const { data } = await apiClient().get<{ data: AuthStatusResponse }>(
-    `/api/auth/lite/auth-status?requestId=${requestId}`
+    "/api/auth/lite/auth-status",
+    { params: { requestId } }
   );
   return data?.data ?? null;
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,8 +1,9 @@
 // =============================================================================
 // Axios HTTP client for the ACP API.
+// Retries on 429 (rate limit) and 5xx with exponential backoff to avoid abuse.
 // =============================================================================
 
-import axios from "axios";
+import axios, { type InternalAxiosRequestConfig } from "axios";
 import dotenv from "dotenv";
 import { loadApiKey } from "./config.js";
 
@@ -10,6 +11,13 @@ dotenv.config();
 
 // Ensure API key is loaded from config
 loadApiKey();
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 const client = axios.create({
   baseURL: process.env.ACP_API_URL || "https://claw-api.virtuals.io",
@@ -20,7 +28,21 @@ const client = axios.create({
 
 client.interceptors.response.use(
   (response) => response,
-  (error) => {
+  async (error) => {
+    const config = error.config as InternalAxiosRequestConfig & { _retryCount?: number };
+    const status = error.response?.status;
+    const shouldRetry =
+      (status === 429 || (status != null && status >= 500)) &&
+      config &&
+      (config._retryCount ?? 0) < MAX_RETRIES;
+
+    if (shouldRetry) {
+      config._retryCount = (config._retryCount ?? 0) + 1;
+      const delay = RETRY_DELAY_MS * Math.pow(2, config._retryCount - 1);
+      await sleep(delay);
+      return client.request(config);
+    }
+
     if (error.response) {
       throw new Error(JSON.stringify(error.response.data));
     }

--- a/src/lib/open.ts
+++ b/src/lib/open.ts
@@ -1,25 +1,24 @@
 // =============================================================================
 // Open a URL in the user's default browser. Platform-specific, no dependencies.
+// Uses execFile to avoid shell interpretation of the URL (no command injection).
 // =============================================================================
 
-import { exec } from "child_process";
+import { execFile } from "child_process";
 
 export function openUrl(url: string): void {
   const platform = process.platform;
-  let cmd: string;
 
-  if (platform === "darwin") {
-    cmd = `open "${url}"`;
-  } else if (platform === "win32") {
-    cmd = `start "" "${url}"`;
-  } else {
-    // Linux / others
-    cmd = `xdg-open "${url}"`;
-  }
-
-  exec(cmd, (err) => {
+  const cb = (err: Error | null) => {
     if (err) {
       // Silently fail — the URL is always printed as fallback
     }
-  });
+  };
+
+  if (platform === "darwin") {
+    execFile("open", [url], {}, cb);
+  } else if (platform === "win32") {
+    execFile("cmd", ["/c", "start", "", url], {}, cb);
+  } else {
+    execFile("xdg-open", [url], {}, cb);
+  }
 }

--- a/src/lib/openclawCron.ts
+++ b/src/lib/openclawCron.ts
@@ -9,7 +9,7 @@
 // run `acp bounty poll --json` and act on the results.
 // =============================================================================
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { ROOT, readConfig, writeConfig } from "./config.js";
 import { listActiveBounties } from "./bounty.js";
 
@@ -36,7 +36,7 @@ const POLL_SYSTEM_EVENT = [
 ].join("\n");
 
 function runCli(args: string[]): string {
-  return execSync(`openclaw cron ${args.join(" ")}`, {
+  return execFileSync("openclaw", ["cron", ...args], {
     cwd: ROOT,
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf-8",

--- a/src/seller/runtime/seller.ts
+++ b/src/seller/runtime/seller.ts
@@ -108,6 +108,15 @@ async function handleNewTask(data: AcpJobEventData): Promise<void> {
       return;
     }
 
+    const knownOfferings = listOfferings(agentDirName);
+    if (!knownOfferings.includes(offeringName)) {
+      await acceptOrRejectJob(jobId, {
+        accept: false,
+        reason: "Unknown offering",
+      });
+      return;
+    }
+
     try {
       const { config, handlers } = await loadOffering(offeringName, agentDirName);
 
@@ -172,7 +181,7 @@ async function handleNewTask(data: AcpJobEventData): Promise<void> {
     const offeringName = resolveOfferingName(data);
     const requirements = resolveServiceRequirements(data);
 
-    if (offeringName) {
+    if (offeringName && listOfferings(agentDirName).includes(offeringName)) {
       try {
         const { handlers } = await loadOffering(offeringName, agentDirName);
         console.log(


### PR DESCRIPTION
# Security & abuse-detection fixes

Summary of changes for this PR.

## 1. Seller runtime

- **Path traversal:** `loadOffering` now validates that the resolved path stays under the offerings root (`ensurePathUnderRoot` in `src/seller/runtime/offerings.ts`). Prevents `offeringName` from the socket (e.g. `".."` or `"../etc"`) from escaping the offerings directory.
- **Known offerings only:** The seller accepts only offering names that exist in `listOfferings(agentDirName)`. Unknown names are rejected with "Unknown offering" (REQUEST) or skipped (TRANSACTION). Applied in `src/seller/runtime/seller.ts`.

## 2. Auth

- **Request ID in URL:** `getAuthStatus(requestId)` now uses axios `params: { requestId }` instead of building the query string with a template literal. Avoids query parameter injection when `requestId` contains `&` or `=` (`src/lib/auth.ts`).

## 3. API client

- **Retry with backoff:** On 429 (rate limit) or 5xx, the client retries up to 3 times with exponential backoff (1s, 2s, 4s). Reduces aggressive request loops (`src/lib/client.ts`).

## 4. Shell / command injection

- **Railway variables:** `setVariable` and `deleteVariable` use `execFileSync("railway", ["variables", "set", \`${key}=${value}\`], ...)` and `execFileSync("railway", ["variables", "delete", key], ...)` so key/value are not parsed by a shell (`src/deploy/railway.ts`).
- **Login URL:** `openUrl` uses `execFile` with the URL as a single argument (`open` / `cmd` / `xdg-open`) instead of building a shell command (`src/lib/open.ts`).
- **OpenClaw cron:** `runCli` uses `execFileSync("openclaw", ["cron", ...args], ...)` instead of `execSync(\`openclaw cron ${args.join(" ")}\`)` (`src/lib/openclawCron.ts`).

## Files changed

| File | Change |
|------|--------|
| `src/seller/runtime/offerings.ts` | Path-under-root check (`ensurePathUnderRoot`) |
| `src/seller/runtime/seller.ts` | Whitelist: only known offerings |
| `src/lib/auth.ts` | `getAuthStatus`: use `params` for `requestId` |
| `src/lib/client.ts` | Retry with backoff on 429/5xx |
| `src/deploy/railway.ts` | `execFileSync` for setVariable/deleteVariable |
| `src/lib/open.ts` | `execFile` for openUrl (no shell) |
| `src/lib/openclawCron.ts` | `execFileSync` for cron CLI |
