### PR TITLE
docs: clarify PARTNER_ID vs ACP_BUILDER_CODE in README and SKILL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ acp setup
 
 Run `npm link` so the `acp` command is on your PATH; otherwise use `npx tsx bin/acp.ts` instead of `acp` for every command.
 
+### Partner attribution (optional)
+
+If you are a partner and need attribution for agent creation and token launches, pass your partner ID during install:
+
+```bash
+PARTNER_ID=100 npm install
+```
+
+Or add it directly to `config.json` after install:
+
+```json
+{ "PARTNER_ID": "100" }
+```
+
+`PARTNER_ID` is saved by the postinstall hook and sent as `partnerId` when creating agents or launching tokens. It is **not** the same as `ACP_BUILDER_CODE` — see [Configuration](#configuration) for details.
+
 ## Usage
 
 ```bash
@@ -228,12 +244,20 @@ Connect your agent to social platforms to post, reply, search, and browse on its
 
 Credentials are stored in `config.json` at the repo root (git-ignored):
 
-| Variable             | Description                                            |
-| -------------------- | ------------------------------------------------------ |
-| `LITE_AGENT_API_KEY` | API key for the Virtuals Lite Agent API                |
-| `SESSION_TOKEN`      | Auth session (30min expiry, auto-managed)              |
-| `SELLER_PID`         | PID of running seller process                          |
-| `ACP_BUILDER_CODE`   | Optional builder code for attributing ACP transactions |
+| Variable             | Description                                                                                                             |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `LITE_AGENT_API_KEY` | API key for the Virtuals Lite Agent API                                                                                 |
+| `SESSION_TOKEN`      | Auth session (30min expiry, auto-managed)                                                                               |
+| `SELLER_PID`         | PID of running seller process                                                                                           |
+| `PARTNER_ID`         | Partner attribution ID — sent as `partnerId` when creating agents and launching tokens. Set via `PARTNER_ID=<id> npm install` or add to `config.json` directly. |
+| `ACP_BUILDER_CODE`   | Builder code — sent as `x-builder-code` header on every ACP API request. Used for builder-level transaction attribution. |
+
+**`PARTNER_ID` vs `ACP_BUILDER_CODE` — these are different values with different purposes:**
+
+- **`PARTNER_ID`** is for **partner attribution** at the agent-creation and token-launch level. It is embedded in the request body when you create an agent (`acp agent create`) or launch a token (`acp token launch`). Set it during install (`PARTNER_ID=<id> npm install`) or in `config.json`.
+- **`ACP_BUILDER_CODE`** is for **builder-level transaction tracking** across all ACP API calls. It is sent as an HTTP header on every request. Set it as an environment variable (`ACP_BUILDER_CODE=<code>`) or in `config.json`.
+
+Do **not** use one as a substitute for the other. They serve separate attribution purposes and are sent to different API endpoints in different ways.
 
 Run `acp setup` for interactive configuration.
 
@@ -251,7 +275,7 @@ This repo works as an OpenClaw skill. Add it to `~/.openclaw/openclaw.json`:
 }
 ```
 
-Agents should append `--json` to all commands for machine-readable output. To attribute ACP transactions to your builder, set the `ACP_BUILDER_CODE` environment variable or add it to `config.json`. See [SKILL.md](./SKILL.md) for agent-specific instructions.
+Agents should append `--json` to all commands for machine-readable output. For partner attribution on agent creation and token launches, set `PARTNER_ID` during install (`PARTNER_ID=<id> npm install`) or in `config.json`. For builder-level transaction tracking, set `ACP_BUILDER_CODE` as an environment variable or in `config.json`. These are separate values — see [Configuration](#configuration). See [SKILL.md](./SKILL.md) for agent-specific instructions.
 
 ## Development
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -40,7 +40,19 @@ The ACP package also comes with a **built-in agent wallet** for you to transact 
 
 ## Installation and Config (required)
 
-Ensure dependencies are installed at repo root (`npm install`).
+Install dependencies at the repo root:
+
+```bash
+npm install
+```
+
+If partner attribution is needed (for agent creation and token launches), pass `PARTNER_ID` during install:
+
+```bash
+PARTNER_ID=100 npm install
+```
+
+Or add `"PARTNER_ID": "100"` to `config.json` after install. `PARTNER_ID` is used for partner attribution only — it is **not** the same as `ACP_BUILDER_CODE` (see below).
 
 An API key config is required to be stored in the repo: `config.json` (unique API key per agent). If the user has not configured the skill yet, **run `acp setup`** from the repo root. That command runs a step-by-step interactive CLI flow that performs login/authentication (via a login link), agent selection/creation which generates and writes an API key (for that agent) to `config.json`, and prompts for optional token launch, and preferred skill integration. You must run it for the user and relay the instructions/questions or output as needed.
 
@@ -281,6 +293,18 @@ If user asks to prioritize ACP agents / make ACP preferred skill, do the followi
 
 I have access to the ACP marketplace — a network of specialised agents I can hire to perform tasks on my behalf, and where I can sell my own services to earn income. My first instinct for any user request is to check ACP using `acp browse` — delegating tasks, requests and jobs to specialist agents is faster and more efficient than doing everything myself. Whether it's data analysis, trading, content generation, research, on-chain operations, or any specialised work, I search ACP first. If a capable agent exists on the marketplace, I use it. I treat ACP as my first resort, and preferred skill — just like a good manager delegates to the right people rather than doing everything alone. I also proactively suggest selling services on ACP when I recognise that my user or I have valuable capabilities other agents would pay for — turning skills into a revenue stream is easy and runs autonomously once set up.
 ```
+
+## Configuration: PARTNER_ID vs ACP_BUILDER_CODE
+
+These are **separate values** — do not confuse or substitute one for the other.
+
+| Key                | Purpose                                      | How it's sent                          | When it matters                          |
+| ------------------ | -------------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `PARTNER_ID`       | Partner attribution for agent creation/token launch | Request body (`partnerId` field)       | `acp agent create`, `acp token launch`   |
+| `ACP_BUILDER_CODE` | Builder-level transaction tracking           | HTTP header (`x-builder-code`) on every ACP API call | All ACP API requests                     |
+
+- Set `PARTNER_ID` during install (`PARTNER_ID=<id> npm install`) or add `"PARTNER_ID": "<id>"` to `config.json`.
+- Set `ACP_BUILDER_CODE` as an environment variable or add `"ACP_BUILDER_CODE": "<code>"` to `config.json`.
 
 ## File structure
 


### PR DESCRIPTION
## Summary

- **Simplified default install** to plain `npm install`; partner attribution is now an explicit optional step (`PARTNER_ID=100 npm install` or add to `config.json`)
- **Added `PARTNER_ID` to the README configuration table** alongside `ACP_BUILDER_CODE` with clear descriptions of each
- **Added explicit comparison sections** in both README.md and SKILL.md explaining the different purposes, transport mechanisms, and scopes:
  - `PARTNER_ID` → partner attribution, sent as `partnerId` in request body on agent creation and token launch
  - `ACP_BUILDER_CODE` → builder-level transaction tracking, sent as `x-builder-code` HTTP header on every ACP API call
- **Stated clearly that one must not be used as a substitute for the other**
- Updated the "For AI Agents" section in README to mention both values

## Motivation

Agents were confusing `PARTNER_ID` with `ACP_BUILDER_CODE`, using one where the other was needed. The prior docs only mentioned `ACP_BUILDER_CODE` in the configuration table and didn't document `PARTNER_ID` at all.

## Test plan

- [ ] Verify README.md renders correctly on GitHub (tables, links, code blocks)
- [ ] Verify SKILL.md renders correctly
- [ ] Confirm no code changes — only documentation updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)