### PR TITLE
docs: clarify partner install path and improve postinstall feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ CLI tool for the [Agent Commerce Protocol (ACP)](https://app.virtuals.io/acp) by
 
 ## Quick Start
 
+Clone the repo and install dependencies — choose one of the two paths below.
+
+<table>
+<tr>
+<th>Standard install</th>
+<th>Install with partner attribution</th>
+</tr>
+<tr>
+<td>
+
 ```bash
 git clone https://github.com/Virtual-Protocol/openclaw-acp virtuals-protocol-acp
 cd virtuals-protocol-acp
@@ -20,20 +30,30 @@ npm link
 acp setup
 ```
 
-Run `npm link` so the `acp` command is on your PATH; otherwise use `npx tsx bin/acp.ts` instead of `acp` for every command.
-
-### Partner attribution (optional)
-
-If you are a partner and need attribution for agent creation and token launches, pass your partner ID during install:
+</td>
+<td>
 
 ```bash
-PARTNER_ID=100 npm install
+git clone https://github.com/Virtual-Protocol/openclaw-acp virtuals-protocol-acp
+cd virtuals-protocol-acp
+PARTNER_ID=100 npm install   # replace 100 with your ID
+npm link
+acp setup
 ```
 
-Or add it directly to `config.json` after install:
+</td>
+</tr>
+</table>
 
-```json
-{ "PARTNER_ID": "100" }
+Run `npm link` so the `acp` command is on your PATH; otherwise use `npx tsx bin/acp.ts` instead of `acp` for every command.
+
+> **Note:** `PARTNER_ID` is **optional**. Everything works without it. It is only needed if you are a partner and want attribution for agent creation and token launches. You can always add it later by re-running `PARTNER_ID=<id> npm install` or editing `config.json` directly.
+
+The postinstall step prints a status line so you can confirm whether partner attribution is active:
+
+```
+[ACP] Partner ID saved: 100          ← set
+[ACP] Partner ID: not set (optional) ← not set, and that's fine
 ```
 
 `PARTNER_ID` is saved by the postinstall hook and sent as `partnerId` when creating agents or launching tokens. It is **not** the same as `ACP_BUILDER_CODE` — see [Configuration](#configuration) for details.
@@ -244,13 +264,13 @@ Connect your agent to social platforms to post, reply, search, and browse on its
 
 Credentials are stored in `config.json` at the repo root (git-ignored):
 
-| Variable             | Description                                                                                                             |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `LITE_AGENT_API_KEY` | API key for the Virtuals Lite Agent API                                                                                 |
-| `SESSION_TOKEN`      | Auth session (30min expiry, auto-managed)                                                                               |
-| `SELLER_PID`         | PID of running seller process                                                                                           |
+| Variable             | Description                                                                                                                                                     |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LITE_AGENT_API_KEY` | API key for the Virtuals Lite Agent API                                                                                                                         |
+| `SESSION_TOKEN`      | Auth session (30min expiry, auto-managed)                                                                                                                       |
+| `SELLER_PID`         | PID of running seller process                                                                                                                                   |
 | `PARTNER_ID`         | Partner attribution ID — sent as `partnerId` when creating agents and launching tokens. Set via `PARTNER_ID=<id> npm install` or add to `config.json` directly. |
-| `ACP_BUILDER_CODE`   | Builder code — sent as `x-builder-code` header on every ACP API request. Used for builder-level transaction attribution. |
+| `ACP_BUILDER_CODE`   | Builder code — sent as `x-builder-code` header on every ACP API request. Used for builder-level transaction attribution.                                        |
 
 **`PARTNER_ID` vs `ACP_BUILDER_CODE` — these are different values with different purposes:**
 

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -2,6 +2,8 @@
 // Runs after `npm install`. Saves partner ID to config.json if provided via:
 //   PARTNER_ID=xxx npm install          (recommended)
 //   npm install --partner_id=xxx        (also supported)
+//
+// Always prints partner attribution status so users know the current state.
 
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import { resolve, dirname } from "path";
@@ -11,7 +13,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const CONFIG_PATH = resolve(__dirname, "..", "config.json");
 
 const partnerId = process.env.PARTNER_ID || process.env.npm_config_partner_id;
-if (!partnerId) process.exit(0);
 
 let config = {};
 if (existsSync(CONFIG_PATH)) {
@@ -20,6 +21,12 @@ if (existsSync(CONFIG_PATH)) {
   } catch {}
 }
 
-config.PARTNER_ID = partnerId;
-writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
-console.log(`[ACP] Partner ID saved: ${partnerId}`);
+if (partnerId) {
+  config.PARTNER_ID = partnerId;
+  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
+  console.log(`[ACP] Partner ID saved: ${partnerId}`);
+} else if (config.PARTNER_ID) {
+  console.log(`[ACP] Partner ID (from config): ${config.PARTNER_ID}`);
+} else {
+  console.log("[ACP] Partner ID: not set (optional)");
+}


### PR DESCRIPTION
- Add side-by-side table in README showing standard vs partner install
- Add visible note that PARTNER_ID is optional
- Update postinstall to always print partner attribution status: saved, already in config, or not set (optional)
- Never fail when PARTNER_ID is missing